### PR TITLE
Refactor backend tag determination in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,13 @@ jobs:
       # 2. Download the backend (Visualizer)
       - name: Determine Backend Tag
         id: backend-tag
-        run: echo "tag=${{ github.ref_name == 'main' && 'latest' || 'nightly' }}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            LATEST_TAG=$(gh release view --repo wmBaja/wolftrack-visualizer --json tagName -jq .tagName)
+            echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "tag=nightly" >> $GITHUB_OUTPUT
+          fi
         shell: bash
 
       - name: Download Backend Binary


### PR DESCRIPTION
Updated the backend tag determination logic to fetch the latest tag from GitHub releases for the main branch.